### PR TITLE
Fix typo in global type definitions for vscode-table-cell

### DIFF
--- a/react-vite/src/global.d.ts
+++ b/react-vite/src/global.d.ts
@@ -90,7 +90,7 @@ declare module "react" {
       "vscode-tab-panel": WebComponentProps<VscodeTabPanel>;
       "vscode-table": WebComponentProps<VscodeTable>;
       "vscode-table-body": WebComponentProps<VscodeTableBody>;
-      "vscode-table-body": WebComponentProps<VscodeTableCell>;
+      "vscode-table-cell": WebComponentProps<VscodeTableCell>;
       "vscode-table-header": WebComponentProps<VscodeTableHeader>;
       "vscode-table-header-cell": WebComponentProps<VscodeTableHeaderCell>;
       "vscode-table-row": WebComponentProps<VscodeTableRow>;


### PR DESCRIPTION
Fix for https://github.com/vscode-elements/elements/issues/373